### PR TITLE
Correct `BValue` typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ To be released.
 - Python 3.5 and 3.6 are no more supported.  Instead, Python 3.8, 3.9, and 3.10
   are now officially supported.
 - Added ``show-bencodex``, a CLI program.
+- Added ``BKey`` type.
+- Fixed ``BValue`` type.
 
 
 Version 1.0.1

--- a/bencodex/types.py
+++ b/bencodex/types.py
@@ -1,8 +1,12 @@
-from typing import Any
+from typing import Mapping, Sequence, Union
 
-__all__ = 'BValue',
+__all__ = (
+    "BKey",
+    "BValue",
+)
 
 
-BValue = Any
+BKey = Union[str, bytes]
+BValue = Union[BKey, int, None, Mapping[BKey, "BValue"], Sequence["BValue"]]
 # Mypy currently does not support recursive types.
 # https://github.com/python/mypy/issues/731

--- a/bencodex/writer.py
+++ b/bencodex/writer.py
@@ -48,7 +48,7 @@ def write(value: BValue) -> Generator[bytes, None, None]:
                 return True
             raise TypeError('dictionary key must be a bytes or str')
         items = [
-            (u, k.encode('utf-8') if u else k, v)
+            (u, k.encode('utf-8') if u and isinstance(k, str) else k, v)
             for k, v in value.items()
             for u in [is_unicode(k)]
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ commands =
 [testenv:mypy]
 basepython = python3
 deps =
-    mypy >= 0.971
+    mypy >= 0.981
 commands =
-    mypy --install-types --non-interactive -p bencodex
+    mypy --install-types --non-interactive -p bencodex --enable-recursive-aliases
 
 [flake8]
 exclude =


### PR DESCRIPTION
In Mypy development build (master branch), it became to support recursive types. (See https://github.com/python/mypy/issues/731#issuecomment-1213482527, https://github.com/python/mypy/pull/13297).

This pull request makes the `bencodex-python` package apply it with the development build.