### PR TITLE
Upgrade mypy to 0.990

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ commands =
 [testenv:mypy]
 basepython = python3
 deps =
-    mypy >= 0.981
+    mypy >= 0.990
 commands =
-    mypy --install-types --non-interactive -p bencodex --enable-recursive-aliases
+    mypy --install-types --non-interactive -p bencodex
 
 [flake8]
 exclude =


### PR DESCRIPTION
On 2022 November 8, Mypy 0.990 version was introduced. And it became to use the recursive type feature in default. 

This pull request upgrades Mypy to 0.990.

https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html